### PR TITLE
RF Base stuffs

### DIFF
--- a/src/main/java/minechem/apparatus/prefab/storage/EnergyStorage.java
+++ b/src/main/java/minechem/apparatus/prefab/storage/EnergyStorage.java
@@ -1,0 +1,127 @@
+package minechem.apparatus.prefab.storage;
+
+import minechem.helper.MathHelper;
+import net.minecraft.nbt.NBTTagCompound;
+
+public class EnergyStorage
+{
+    public static boolean freeEnergy;
+    protected int capacity;
+    protected int stored;
+    protected int maxInput;
+    protected int maxOutput;
+
+    public EnergyStorage()
+    {
+        this(1000000);
+    }
+
+    public EnergyStorage(int capacity)
+    {
+        this(capacity, capacity, capacity);
+    }
+
+    public EnergyStorage(int capacity, int maxInput)
+    {
+        this(capacity, maxInput, maxInput);
+    }
+
+    public EnergyStorage(int capacity, int maxInput, int maxOutput)
+    {
+        this.capacity = capacity;
+        this.maxInput = maxInput;
+        this.maxOutput = maxOutput;
+    }
+
+    public EnergyStorage readFromNBT(NBTTagCompound tagCompound)
+    {
+        this.stored = tagCompound.getInteger("Stored");
+        this.stored = Math.max(this.stored, this.capacity);
+        return this;
+    }
+
+    public NBTTagCompound writeToNBT(NBTTagCompound tagCompound)
+    {
+        tagCompound.setInteger("Stored", this.stored);
+        return tagCompound;
+    }
+
+    public int getMaxOutput()
+    {
+        return this.maxOutput;
+    }
+
+    public void setMaxOutput(int maxOutput)
+    {
+        this.maxOutput = maxOutput;
+    }
+
+    public int getMaxInput()
+    {
+        return this.maxInput;
+    }
+
+    public void setMaxInput(int maxInput)
+    {
+        this.maxInput = maxInput;
+    }
+
+    public int getStored()
+    {
+        return this.stored;
+    }
+
+    public void setStored(int stored)
+    {
+        this.stored = MathHelper.clamp(stored, 0, capacity);
+    }
+
+    public int getCapacity()
+    {
+        return this.capacity;
+    }
+
+    public void setCapacity(int capacity)
+    {
+        this.capacity = capacity;
+        if (this.stored > this.capacity) this.stored = this.capacity;
+    }
+
+    public int inputEnergy(int energy, boolean doInsert)
+    {
+        int amount = Math.min(energy, Math.min(this.maxInput, this.capacity - this.stored));
+        if (doInsert) this.stored += amount;
+        return amount;
+    }
+
+    public int extractEnergy(int energy, boolean doExtract)
+    {
+        int amount = Math.min(this.stored, Math.min(energy, maxOutput));
+        if (doExtract) this.stored -= amount;
+        return amount;
+    }
+
+    public boolean hasEnergy(int energy)
+    {
+        return freeEnergy ? true : energy < stored;
+    }
+
+    public boolean consumeEnergy(int energy)
+    {
+        if (freeEnergy) return true;
+        if (hasEnergy(energy))
+        {
+            this.stored -= energy;
+            return true;
+        }
+        return false;
+    }
+
+    public boolean generateEnergy(int energy)
+    {
+        if (freeEnergy) return true;
+        if (this.stored == this.capacity) return false;
+        this.stored = Math.min(this.capacity, this.stored + energy);
+        return true;
+    }
+}

--- a/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFBase.java
+++ b/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFBase.java
@@ -1,0 +1,59 @@
+package minechem.apparatus.prefab.tileEntity.energy;
+
+import minechem.apparatus.prefab.storage.EnergyStorage;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+public abstract class RFBase extends TileEntity
+{
+    protected EnergyStorage energy;
+
+    public RFBase()
+    {
+        energy = new EnergyStorage();
+    }
+
+    public RFBase(int capacity)
+    {
+        energy = new EnergyStorage(capacity);
+    }
+
+    public RFBase(int capacity, int maxTransfer)
+    {
+        energy = new EnergyStorage(capacity, maxTransfer);
+    }
+
+    public RFBase(int capacity, int maxInput, int maxOutput)
+    {
+        energy = new EnergyStorage(capacity, maxInput, maxOutput);
+    }
+
+    public boolean consumeEnergy(int amount)
+    {
+        return this.energy.consumeEnergy(amount);
+    }
+
+    public boolean hasEnergy(int amount)
+    {
+        return this.energy.hasEnergy(amount);
+    }
+
+    public boolean generateEnergy(int amount)
+    {
+        return this.energy.generateEnergy(amount);
+    }
+
+    @Override
+    public void writeToNBT(NBTTagCompound tagCompound)
+    {
+        super.writeToNBT(tagCompound);
+        energy.writeToNBT(tagCompound);
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound tagCompound)
+    {
+        super.readFromNBT(tagCompound);
+        energy.readFromNBT(tagCompound);
+    }
+}

--- a/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFGeneratorBase.java
+++ b/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFGeneratorBase.java
@@ -1,0 +1,37 @@
+package minechem.apparatus.prefab.tileEntity.energy;
+
+import cofh.api.energy.IEnergyProvider;
+import cpw.mods.fml.common.Optional;
+import net.minecraftforge.common.util.ForgeDirection;
+
+@Optional.Interface(iface = "cofh.api.energy.IEnergyProvider", modid = "CoFHAPI|energy")
+public class RFGeneratorBase extends RFBase implements IEnergyProvider
+{
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int extractEnergy(ForgeDirection forgeDirection, int amount, boolean doExtract)
+    {
+        return this.energy.extractEnergy(amount, doExtract);
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int getEnergyStored(ForgeDirection forgeDirection)
+    {
+        return this.energy.getStored();
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int getMaxEnergyStored(ForgeDirection forgeDirection)
+    {
+        return this.energy.getCapacity();
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public boolean canConnectEnergy(ForgeDirection forgeDirection)
+    {
+        return true;
+    }
+}

--- a/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFHandlerBase.java
+++ b/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFHandlerBase.java
@@ -1,0 +1,16 @@
+package minechem.apparatus.prefab.tileEntity.energy;
+
+import cofh.api.energy.IEnergyProvider;
+import cpw.mods.fml.common.Optional;
+import net.minecraftforge.common.util.ForgeDirection;
+
+@Optional.Interface(iface = "cofh.api.energy.IEnergyProvider", modid = "CoFHAPI|energy")
+public class RFHandlerBase extends RFMachineBase implements IEnergyProvider
+{
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int extractEnergy(ForgeDirection forgeDirection, int amount, boolean doExtract)
+    {
+        return this.energy.extractEnergy(amount, doExtract);
+    }
+}

--- a/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFMachineBase.java
+++ b/src/main/java/minechem/apparatus/prefab/tileEntity/energy/RFMachineBase.java
@@ -1,0 +1,37 @@
+package minechem.apparatus.prefab.tileEntity.energy;
+
+import cofh.api.energy.IEnergyReceiver;
+import cpw.mods.fml.common.Optional;
+import net.minecraftforge.common.util.ForgeDirection;
+
+@Optional.Interface(iface = "cofh.api.energy.IEnergyReceiver", modid = "CoFHAPI|energy")
+public class RFMachineBase extends RFBase implements IEnergyReceiver
+{
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int receiveEnergy(ForgeDirection forgeDirection, int amount, boolean doInsert)
+    {
+        return this.energy.inputEnergy(amount, doInsert);
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int getEnergyStored(ForgeDirection forgeDirection)
+    {
+        return this.energy.getStored();
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public int getMaxEnergyStored(ForgeDirection forgeDirection)
+    {
+        return this.energy.getCapacity();
+    }
+
+    @Optional.Method(modid = "CoFHAPI|energy")
+    @Override
+    public boolean canConnectEnergy(ForgeDirection forgeDirection)
+    {
+        return true;
+    }
+}

--- a/src/main/java/minechem/helper/MathHelper.java
+++ b/src/main/java/minechem/helper/MathHelper.java
@@ -1,0 +1,11 @@
+package minechem.helper;
+
+public class MathHelper
+{
+    public static int clamp(int val, int min, int max)
+    {
+        if (val<min) return min;
+        if (val>max) return max;
+        return val;
+    }
+}


### PR DESCRIPTION
Use MachineBase for RF consumers, GeneratorBase for RF suppliers,
HandlerBase for stuff with RF i/o like storage or something

machines should only use the has/consume/generate-Energy methods in
RFBase

EnergyStorage.freeEnergy if set to true, will prevent any energy being
used or generated