### PR TITLE
Revert "Fix COFH lib download in gradle [DrZed]"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,8 @@ task getLibraries {
         }
     }
 
-    def cofhSource = 'http://minecraft.curseforge.com/mc-mods/220333-cofhlib/files/2228469/download'
-    def cofhDest = new File('libs', 'CoFHLib-[1.7.10]1.0.0B9-118.jar') 
+    def cofhSource = 'http://minecraft.curseforge.com/mc-mods/220333-cofhlib/files/2225609/download'
+    def cofhDest = new File('libs', 'CoFHLib-1.7.10-1.0.0B9-68-dev.jar')
 
     if(!cofhDest.exists() ){
         download {


### PR DESCRIPTION
Reverts jakimfett/Minechem#667
Pull Request causes error: 
BasicGuiContainer is not abstract and does not override abstract method drawGuiContainerBackgroundLayer(float,int,int) in GuiContainer

@MFernflower make sure to check that updating a lib/API doesn't break stuff before making a PR, ok?