### PR TITLE
Fix one chemical reaction may return two empty buckets

### DIFF
--- a/src/main/java/minechem/fluid/reaction/ChemicalFluidReactionHandler.java
+++ b/src/main/java/minechem/fluid/reaction/ChemicalFluidReactionHandler.java
@@ -50,6 +50,12 @@ public class ChemicalFluidReactionHandler
     public void checkEntityItem(World world, EntityItem entityItem)
     {
         ItemStack itemStack = entityItem.getEntityItem();
+        
+        if (itemStack.stackSize <= 0)
+        {
+            return;
+        }
+        
         Item item = itemStack.getItem();
         MinechemChemicalType chemicalA = null;
         if (item instanceof MinechemBucketItem)
@@ -72,12 +78,10 @@ public class ChemicalFluidReactionHandler
                 {
                     chemicalReaction(world, entityItem, x, y, z, rule, !(MinechemUtil.canDrain(world, block, x, y, z)));
                     itemStack.stackSize--;
+                    entityItem.setEntityItemStack(itemStack);
                     if (itemStack.stackSize <= 0)
                     {
                         world.removeEntity(entityItem);
-                    } else
-                    {
-                        entityItem.setEntityItemStack(itemStack);
                     }
                     MinechemUtil.throwItemStack(world, new ItemStack(Items.bucket), x, y, z);
                 }


### PR DESCRIPTION
because one entity may be traversed more than one time and one entity
won't be removed utill next tick