### PR TITLE
Bump CoFHLib version to 1.0.2-160

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,8 +153,8 @@ task getLibraries {
 		}
 	}
 
-    def cofhSource = 'http://minecraft.curseforge.com/mc-mods/220333-cofhlib/files/2230208/download'
-    def cofhDest = new File('libs', 'CoFHLib-1.7.10-1.0.0RC7-127-dev.jar')
+    def cofhSource = 'http://minecraft.curseforge.com/mc-mods/220333-cofhlib/files/2236777/download'
+    def cofhDest = new File('libs', 'CoFHLib-[1.7.10]1.0.2-160-dev.jar')
 
         if(!cofhDest.exists() ){
             download {


### PR DESCRIPTION
because I got a build error

    java.io.FileNotFoundException: http://minecraft.curseforge.com/mc-mods/220333-cofhlib/files/2230208/download?cookieTest=1

CoFHLib has removed the file `CoFHLib-1.7.10-1.0.0RC7-127-dev.jar`