### PR TITLE
Making the Water Bucket to H2O recipe configurable

### DIFF
--- a/src/main/java/minechem/Settings.java
+++ b/src/main/java/minechem/Settings.java
@@ -73,6 +73,9 @@ public class Settings
     public static boolean reactionItemMeetFluid = true;
     public static boolean reactionFluidMeetFluid = true;
 
+    // Enable Water Bucket --> 8 H2O recipe in crafting grid
+    public static boolean enableWaterBucketIntoH2ORecipe = true;
+
     // NEI support
     public static boolean supportNEI = true;
 
@@ -229,6 +232,12 @@ public class Settings
         prop.comment = StatCollector.translateToLocal("config.supportNEI.description");
         prop.setLanguageKey("config.supportNEI.name");
         supportNEI = prop.getBoolean();
+        configList.add(prop.getName());
+
+        prop = config.get(Configuration.CATEGORY_GENERAL, "enableWaterBucketIntoH2ORecipe", Settings.enableWaterBucketIntoH2ORecipe);
+        prop.comment = StatCollector.translateToLocal("config.enableWaterBucketIntoH2ORecipe.description");
+        prop.setLanguageKey("config.enableWaterBucketIntoH2ORecipe.name");
+        enableWaterBucketIntoH2ORecipe = prop.getBoolean();
         configList.add(prop.getName());
 
         prop = config.get("blacklist", "decomposition", new String[]

--- a/src/main/java/minechem/item/bucket/MinechemBucketReverseRecipe.java
+++ b/src/main/java/minechem/item/bucket/MinechemBucketReverseRecipe.java
@@ -5,6 +5,7 @@ import minechem.item.MinechemChemicalType;
 import minechem.item.element.ElementEnum;
 import minechem.item.molecule.MoleculeEnum;
 import minechem.radiation.RadiationEnum;
+import minechem.Settings;
 import net.minecraft.init.Items;
 import net.minecraft.inventory.InventoryCrafting;
 import net.minecraft.item.ItemStack;
@@ -53,6 +54,11 @@ public class MinechemBucketReverseRecipe implements IRecipe
                 }
             } else if (itemStack.getItem() == Items.water_bucket)
             {
+                if (!Settings.enableWaterBucketIntoH2ORecipe)
+                {
+                    return false;
+                }
+
                 if (type == null)
                 {
                     type = MoleculeEnum.water;

--- a/src/main/resources/assets/minechem/lang/en_US.lang
+++ b/src/main/resources/assets/minechem/lang/en_US.lang
@@ -84,6 +84,8 @@ config.supportNEI.description=NEI Support
 config.supportNEI.name=Turn NEI support on or off
 config.decomposeFluidChemicals.description=Add Decomposer Recipes for Chemical Fluids
 config.decomposeFluidChemicals.name=Fluids Decomposition
+config.enableWaterBucketIntoH2ORecipe.description=Enable the recipe that lets the player get 8 H2O from a water bucket by putting the water bucket in a crafting grid by itself.
+config.enableWaterBucketIntoH2ORecipe.name=Enable Water Bucket to H2O Recipe
 
 gui.title.decomposer=Chemical Decomposer
 gui.title.decomposer.dump=Dump Fluid


### PR DESCRIPTION
There's a different recipe we wrote in MineTweaker3 that our modpack, at least, would much prefer to see instead of this one.  A change like this appears to be the only way to make that work without throwing out all the chemical bucket --> chemical recipes (if that's even possible).

N.B.: to test this with the latest version of Gradle (2.10), I had to tweak build.gradle to bump `gradle-download-task` up to 2.1.0 (that change is not included in this PR).  Apparently Gradle 2.6 changed some APIs around and [broke gradle-download-task](https://github.com/michel-kraemer/gradle-download-task/issues/29).